### PR TITLE
Fix sendmail path

### DIFF
--- a/server/example.env
+++ b/server/example.env
@@ -35,3 +35,5 @@ PERSISTENT_ALIAS="alias12@dev.ptorx.com"
 SMTP_SERVER_OPTIONS={"banner":"dev.ptorx.com","name":"dev.ptorx.com","size":25000000}
 
 MAIL_CACHE_DIRECTORY="/home/travis/build/xyfir/ptorx/mail-cache"
+
+SENDMAIL_PATH=sendmail

--- a/server/lib/mail/send.ts
+++ b/server/lib/mail/send.ts
@@ -12,7 +12,7 @@ const transporter =
       })
     : createTransport({
         sendmail: true,
-        path: '/usr/sbin/sendmail'
+        path: process.enve.SENDMAIL_PATH || 'sendmail'
       });
 
 export async function sendMail(

--- a/server/lib/mail/send.ts
+++ b/server/lib/mail/send.ts
@@ -10,7 +10,10 @@ const transporter =
         port: process.enve.TEST_MTA_PORT,
         tls: { rejectUnauthorized: false }
       })
-    : createTransport({ sendmail: true });
+    : createTransport({
+        sendmail: true,
+        path: '/usr/sbin/sendmail'
+      });
 
 export async function sendMail(
   mail: SendMailOptions,

--- a/types/ptorx.d.ts
+++ b/types/ptorx.d.ts
@@ -299,6 +299,11 @@ export namespace Ptorx {
        * @example "/path/to/mail-cache"
        */
       MAIL_CACHE_DIRECTORY: string;
+	  /**
+	   * Absolute path of sendmail command for outgoing mails.
+	   * @example "/usr/sbin/sendmail"
+	   */
+	  SENDMAIL_PATH: string;	   
     }
 
     export interface Web extends Ptorx.Env.Common {

--- a/types/ptorx.d.ts
+++ b/types/ptorx.d.ts
@@ -299,11 +299,11 @@ export namespace Ptorx {
        * @example "/path/to/mail-cache"
        */
       MAIL_CACHE_DIRECTORY: string;
-	  /**
-	   * Absolute path of sendmail command for outgoing mails.
-	   * @example "/usr/sbin/sendmail"
-	   */
-	  SENDMAIL_PATH: string;	   
+      /**
+       * Absolute path of sendmail command for outgoing mails.
+       * @example "/usr/sbin/sendmail"
+       */
+      SENDMAIL_PATH: string;	   
     }
 
     export interface Web extends Ptorx.Env.Common {


### PR DESCRIPTION
Fix sendmail path. At least `sendmail` command of Postfix is placed in `/usr/sbin`.